### PR TITLE
Improve yum cookbook dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ license          'Apache 2.0'
 description      'Configures Dell repositories. Installs OMSA'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '3.0.4'
-depends          'yum'
+depends          'yum', '>= 3'
 name             'yum-dell'
 recipe 'yum-dell::default', 'Installs Dell OpenManage and optionally firmware components.'
 recipe 'yum-dell::omsa', 'Reverses default recipe'


### PR DESCRIPTION
This cookbook requires yum >=3, because it uses the gpgkey attribute, so put that into the metadata.
