### PR TITLE
Changed the default gpg key locations for omsa to match those now in use by Dell.

### DIFF
--- a/attributes/omsa-indep.rb
+++ b/attributes/omsa-indep.rb
@@ -28,6 +28,6 @@ else
   default['yum']['dell']['omsa-indep']['mirrorlist'] = 'http://linux.dell.com/repo/hardware/latest/mirrors.cgi?' +
     "osname=el#{node['platform_version'].to_i}&basearch=$basearch&native=1&dellsysidpluginver=$dellsysidpluginver"
 end
-default['yum']['dell']['omsa-indep']['gpgkey'] = 'http://linux.dell.com/repo/hardware/latest/RPM-GPG-KEY-dell'
+default['yum']['dell']['omsa-indep']['gpgkey'] = 'http://linux.dell.com/repo/hardware/latest/public.key'
 default['yum']['dell']['omsa-indep']['gpgcheck'] = true
 default['yum']['dell']['omsa-indep']['failovermethod'] = 'priority'

--- a/attributes/omsa-specific.rb
+++ b/attributes/omsa-specific.rb
@@ -28,7 +28,7 @@ else
   default['yum']['dell']['omsa-specific']['mirrorlist'] = 'http://linux.dell.com/repo/hardware/latest/mirrors.cgi?' +
     "osname=el#{node['platform_version'].to_i}&basearch=$basearch&native=1&sys_ven_id=$sys_ven_id&sys_dev_id=$sys_dev_id&dellsysidpluginver=$dellsysidpluginver"
 end
-default['yum']['dell']['omsa-specific']['gpgkey'] = 'http://linux.dell.com/repo/hardware/latest/RPM-GPG-KEY-dell'
+default['yum']['dell']['omsa-specific']['gpgkey'] = 'http://linux.dell.com/repo/hardware/latest/public.key'
 default['yum']['dell']['omsa-specific']['gpgcheck'] = true
 default['yum']['dell']['omsa-specific']['failovermethod'] = 'priority'
 default['yum']['dell']['omsa-specific']['packages'] = %w[ srvadmin-all ]


### PR DESCRIPTION
Looks like Dell changed the file name for their GPG keys. This is an attribute only fix, so in case this never gets pulled (the repo is pretty inactive) you can do this through a wrapper cookbook with something like:
```
default['yum']['dell']['omsa-specific']['gpgkey'] = 'http://linux.dell.com/repo/hardware/latest/public.key'
default['yum']['dell']['omsa-indep']['gpgkey'] = 'http://linux.dell.com/repo/hardware/latest/public.key'
```